### PR TITLE
Feature/update docker settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10.2
 WORKDIR /home/docker/app
 RUN adduser -u 1000 -s /bin/sh -D docker \
-  && apk add fish=3.0.2-r3 nodejs=10.16.3-r0 npm=10.16.3-r0 \
+  && apk add fish=3.0.2-r3 nodejs=10.16.3-r0 npm=10.16.3-r0 git=2.22.0-r0 \
   && npm i -g @vue/cli@4.0.3
 USER docker
 CMD [ "fish" ]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "lint-docker-stop": "npx lint-staged && exit",
+    "pre-push": "docker-compose run --rm app npm run lint-docker-stop"
   },
   "dependencies": {
     "core-js": "^3.1.2",
@@ -25,5 +27,14 @@
     "prettier": "^1.18.2",
     "sass-loader": "^8.0.0",
     "vue-template-compiler": "^2.6.10"
+  },
+  "gitHooks": {
+    "pre-push": "npm run pre-push"
+  },
+  "lint-staged": {
+    "*.{js,vue}": [
+      "vue-cli-service lint",
+      "git add"
+    ]
   }
 }


### PR DESCRIPTION
gitHooksによるコミット時のeslintがホストOS側で走ってしまう問題を、解決させました。

## 変更内容
- git push時にDockerコンテナを立ちあげ、コンテナ内でeslintが走るように変更
- コンテナ内でlint-stagedを使用するときに、ゲストOSにgitが必要だったためDockerfileに追記